### PR TITLE
Fix for reference paths problem when multiple RAML files are processe…

### DIFF
--- a/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -294,6 +294,7 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo {
 				if(line.startsWith("#%RAML")) {
 					getLog().info("Generating Java classes from: " + ramlFile);
 					configuration.setBasePackageName(basePackageName.concat(computeSubPackageName(ramlFile)));
+					configuration.setSourceDirectory(ramlFile.getParentFile());
 					generator.run(new FileReader(ramlFile), configuration, ramlFile.getAbsolutePath());
 				}
 				else{

--- a/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -15,18 +15,6 @@
  */
 package org.raml.jaxrs.codegen.maven;
 
-import static org.apache.maven.plugins.annotations.ResolutionScope.COMPILE_PLUS_RUNTIME;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -40,7 +28,20 @@ import org.jsonschema2pojo.AnnotationStyle;
 import org.raml.jaxrs.codegen.core.Configuration;
 import org.raml.jaxrs.codegen.core.Configuration.JaxrsVersion;
 import org.raml.jaxrs.codegen.core.GeneratorProxy;
+import org.raml.jaxrs.codegen.core.Names;
 import org.raml.jaxrs.codegen.core.ext.GeneratorExtension;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.maven.plugins.annotations.ResolutionScope.COMPILE_PLUS_RUNTIME;
 
 /**
  * When invoked, this goals read one or more <a href="http://raml.org">RAML</a>
@@ -341,7 +342,7 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo {
 				String parent = rel.getParent().toString();
 				String rpn = parent.replace(File.separator, ".");
 				if (StringUtils.isNotBlank(rpn)) {
-					subName = ".".concat(rpn);
+					subName = ".".concat(Names.buildVariableName(rpn).toLowerCase());
 				}
 			}
 		}

--- a/raml-to-jaxrs/maven-plugin/src/test/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojoTest.java
+++ b/raml-to-jaxrs/maven-plugin/src/test/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojoTest.java
@@ -1,10 +1,11 @@
 package org.raml.jaxrs.codegen.maven;
 
-import java.io.File;
-
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
 
 
 
@@ -29,6 +30,7 @@ public class RamlJaxrsCodegenMojoTest  {
 		assertEquals(".v2", mojo.computeSubPackageName(new File("src/raml/v2/widgets.raml")));
 		assertEquals("", mojo.computeSubPackageName(new File("src/raml/widgets.raml")));
 		assertEquals(".v1", mojo.computeSubPackageName(new File("src/raml/v1/widgets.raml")));
+		assertEquals(".productsummary", mojo.computeSubPackageName(new File("src/raml/product-summary/widgets.raml")));
 	}
 	
 	@Test
@@ -39,6 +41,7 @@ public class RamlJaxrsCodegenMojoTest  {
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v1/widgets.raml")));
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v2/widgets.raml")));
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("src/raml/product-summary/widgets.raml")));
 	}
 	
 	@Test
@@ -49,6 +52,7 @@ public class RamlJaxrsCodegenMojoTest  {
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v1/widgets.raml")));
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v2/widgets.raml")));
 		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("src/raml/product-summary/widgets.raml")));
 	}
 
 }


### PR DESCRIPTION
This PR contains actually two fixes:
1. Fix for reference paths problem when multiple RAML files are processed at once (using `<sourcePaths>` configuration).
   Without this fix, relative paths of included JSON Schema files are not resolved properly, because some baseURL is not set. This PR fixes that problem.
   The problem is only apparent if the `<sourceFiles>` maven configuration is used.
2. Fixed package naming problem which occurs when the following conditions are met:
   1. The `<useSourceHierarchyInPackageName>` config option is set to true;
   2. The RAML file being processed resides in a directory (sub package) which is not a legal Java identifier (e.g., `.../product-summary/widgets.raml`).
      The package naming issue is fixed by passing it through: `Names.buildVariableName(rpn).toLowerCase()`
