### PR TITLE
Fixed some ClassCastException.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,8 @@ nogit/
 RemoteSystemsTempFiles
 /.gradle
 .DS_Store
-pom.xml.versionsBackup
+.classpath
+.settings
+.project
+bin
+.gitignore

--- a/jaxrs-to-raml/jaxrs-parser/src/main/java/org/raml/jaxrs/parser/model/JerseyJaxRsEntity.java
+++ b/jaxrs-to-raml/jaxrs-parser/src/main/java/org/raml/jaxrs/parser/model/JerseyJaxRsEntity.java
@@ -21,6 +21,7 @@ import org.raml.jaxrs.model.JaxRsEntity;
 import org.raml.jaxrs.parser.source.SourceParser;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 /**
@@ -58,7 +59,6 @@ public class JerseyJaxRsEntity implements JaxRsEntity {
     return new JerseyJaxRsEntity(input.getType(), sourceParser);
   }
 
-
   static Optional<JaxRsEntity> create(Type input, SourceParser sourceParser) {
 
     if (input == null) {
@@ -72,6 +72,13 @@ public class JerseyJaxRsEntity implements JaxRsEntity {
   @Override
   public <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType) {
 
-    return (Optional<T>) Optional.fromNullable(((Class) input).getAnnotation(annotationType));
+    Type type = input;
+    if (type instanceof ParameterizedType) {
+      ParameterizedType pt = (ParameterizedType) type;
+      type = pt.getRawType();
+    }
+
+    Class c = (Class) type;
+    return (Optional<T>) Optional.fromNullable(((Class) type).getAnnotation(annotationType));
   }
 }

--- a/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/emitters/AnnotationInstanceEmitter.java
+++ b/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/emitters/AnnotationInstanceEmitter.java
@@ -39,11 +39,11 @@ import java.util.List;
 public class AnnotationInstanceEmitter implements LocalEmitter {
 
   private final IndentedAppendable writer;
-  private final List<RamlSupportedAnnotation> suportedAnnotations;
+  private final List<RamlSupportedAnnotation> supportedAnnotations;
 
   public AnnotationInstanceEmitter(IndentedAppendable writer, List<RamlSupportedAnnotation> supportedAnnotation) {
     this.writer = writer;
-    this.suportedAnnotations = supportedAnnotation;
+    this.supportedAnnotations = supportedAnnotation;
   }
 
   @Override
@@ -65,7 +65,7 @@ public class AnnotationInstanceEmitter implements LocalEmitter {
   }
 
   private void annotate(Annotable annotable) throws IOException {
-    for (RamlSupportedAnnotation suportedAnnotation : suportedAnnotations) {
+    for (RamlSupportedAnnotation suportedAnnotation : supportedAnnotations) {
 
       Optional<Annotation> annotationOptional = suportedAnnotation.getAnnotationInstance(annotable);
       if (annotationOptional.isPresent() == false) {

--- a/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/handlers/SimpleJacksonTypes.java
+++ b/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/handlers/SimpleJacksonTypes.java
@@ -32,6 +32,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.ParameterizedType;
 
 /**
  * Created by Jean-Philippe Belanger on 3/26/17. Just potential zeroes and ones
@@ -61,11 +63,19 @@ public class SimpleJacksonTypes implements TypeHandler {
   private static class SimpleJaxbTypeScanner implements TypeScanner {
 
     @Override
-    public void scanType(TypeRegistry typeRegistry, RamlEntity type, RamlType ramlType) {
+    public void scanType(TypeRegistry typeRegistry, RamlEntity ramlEntity, RamlType ramlType) {
+      Type type = ramlEntity.getType();
+      if (type instanceof ParameterizedType) {
+        ParameterizedType pt = (ParameterizedType) type;
+        type = pt.getRawType();
+      };
+      if (type instanceof TypeVariable) {
+        type = (Class) ((TypeVariable) type).getGenericDeclaration();
+      }
 
-      Class c = (Class) type.getType();
-      forFields(typeRegistry, type, ramlType, c);
-      forProperties(typeRegistry, type, ramlType, c);
+      Class c = (Class) type;
+      forFields(typeRegistry, ramlEntity, ramlType, c);
+      forProperties(typeRegistry, ramlEntity, ramlType, c);
     }
 
     private void forProperties(TypeRegistry typeRegistry, RamlEntity type, RamlType ramlType, Class c) {

--- a/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/types/RamlType.java
+++ b/jaxrs-to-raml/raml-generator-api/src/main/java/org/raml/jaxrs/types/RamlType.java
@@ -79,9 +79,9 @@ public class RamlType implements Annotable, Emittable {
       ttype = pt.getRawType();
     }
     if (ttype instanceof TypeVariable) {
+      System.out.println("Ignored type: " + type);
       System.out.println("emitter: " + emitter);
-      System.out.println("type: " + type);
-      System.out.println("ttype: " + ttype);
+      System.out.println("type.getType(): " + ttype);
       return;
     }
 


### PR DESCRIPTION
They were caused by the casting to (Class) of a type that was a java.lang.reflect.ParameterizedType or java.lang.reflect.TypeVariable.
This seems to happen when the type to generate is for a class that contains generics