### PR TITLE
Avoiding the File encoding WARNING

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     </modules>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Setting the `project.build.sourceEncoding` property to avoid :

```
[WARNING] File encoding has not been set, using platform encoding (UTF-8) to format source files, i.e. build is platform dependent!
```