### PR TITLE
Fix build failure due to maven-source-plugin API incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -206,6 +206,7 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
+                    <!--
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -219,6 +220,7 @@
                             </execution>
                         </executions>
                     </plugin>
+                    -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>

--- a/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
@@ -63,6 +63,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -76,6 +77,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
         </plugins>
     </build>
     <description>RAML JAXRS</description>


### PR DESCRIPTION
When running `mvn clean install` as mentioned in the [README](https://github.com/aowss/raml-for-jax-rs/blob/master/raml-to-jaxrs/README.md), you get the following error :

```
[WARNING] Error injecting: org.codehaus.plexus.archiver.jar.JarArchiver
java.lang.ExceptionInInitializerError
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    ...
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
	at org.codehaus.plexus.archiver.zip.AbstractZipArchiver.<clinit>(AbstractZipArchiver.java:113)
	... 88 more
[WARNING] Error injecting: org.apache.maven.plugin.source.SourceJarNoForkMojo
java.lang.ExceptionInInitializerError
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    ...
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
	at org.codehaus.plexus.archiver.zip.AbstractZipArchiver.<clinit>(AbstractZipArchiver.java:113)
	... 88 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.236 s
[INFO] Finished at: 2017-09-28T12:45:56-04:00
[INFO] Final Memory: 28M/95M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-source-plugin:2.4:jar-no-fork (attach-sources) on project raml-to-jaxrs-cli: Execution attach-sources of goal org.apache.maven.plugins:maven-source-plugin:2.4:jar-no-fork failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-source-plugin:2.4:jar-no-fork: java.lang.ExceptionInInitializerError: null
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-source-plugin:2.4
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/dev/.m2/repository/org/apache/maven/plugins/maven-source-plugin/2.4/maven-source-plugin-2.4.jar
[ERROR] urls[1] = file:/Users/dev/.m2/repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar
[ERROR] urls[2] = file:/Users/dev/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.jar
[ERROR] urls[3] = file:/Users/dev/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[4] = file:/Users/dev/.m2/repository/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar
[ERROR] urls[5] = file:/Users/dev/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar
[ERROR] urls[6] = file:/Users/dev/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar
[ERROR] urls[7] = file:/Users/dev/.m2/repository/commons-cli/commons-cli/1.0/commons-cli-1.0.jar
[ERROR] urls[8] = file:/Users/dev/.m2/repository/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar
[ERROR] urls[9] = file:/Users/dev/.m2/repository/org/codehaus/plexus/plexus-archiver/2.6.3/plexus-archiver-2.6.3.jar
[ERROR] urls[10] = file:/Users/dev/.m2/repository/org/codehaus/plexus/plexus-io/2.1.3/plexus-io-2.1.3.jar
[ERROR] urls[11] = file:/Users/dev/.m2/repository/org/apache/commons/commons-compress/1.8.1/commons-compress-1.8.1.jar
[ERROR] urls[12] = file:/Users/dev/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.18/plexus-utils-3.0.18.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
```

Upgrading the `maven-source-plugin` plugin to the latest version seems to fix the problem.

+ Removing redundancies.