### PR TITLE
Fix @JsonAnySetter method signature

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>build-tools</artifactId>

--- a/jaxrs-to-raml/jaxrs-api/pom.xml
+++ b/jaxrs-to-raml/jaxrs-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-api</artifactId>

--- a/jaxrs-to-raml/jaxrs-parser/pom.xml
+++ b/jaxrs-to-raml/jaxrs-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-parser</artifactId>

--- a/jaxrs-to-raml/jaxrs-test-resources/pom.xml
+++ b/jaxrs-to-raml/jaxrs-test-resources/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-test-resources</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-cli/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-cli</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-converter/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-converter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-converter</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-core/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-core</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/build.gradle
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
     apply plugin: 'java'
     group 'org.raml.jaxrs'
-    version '2.1.1-SNAPSHOT'
+    version '2.1.2-SNAPSHOT'
     repositories {
         mavenLocal()
         maven { url 'https://repository.mulesoft.org/snapshots/' }
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.raml.jaxrs:jaxrs-to-raml-gradle-plugin:2.1.1-SNAPSHOT"
+        classpath "org.raml.jaxrs:jaxrs-to-raml-gradle-plugin:2.1.2-SNAPSHOT"
     }
 }
 

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/gradle-jaxrs-to-raml-annotations/build.gradle
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/gradle-jaxrs-to-raml-annotations/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile "javax.ws.rs:javax.ws.rs-api:2.0.1"
-    compile "org.raml.jaxrs:raml-generator-api:2.1.1-SNAPSHOT"
-    compile "org.raml.jaxrs:raml-emitter:2.1.1-SNAPSHOT"
+    compile "org.raml.jaxrs:raml-generator-api:2.1.2-SNAPSHOT"
+    compile "org.raml.jaxrs:raml-emitter:2.1.2-SNAPSHOT"
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:2.24"
 }
 

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-gradle-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-annotations/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-annotations</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-methods/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-methods/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-methods</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-multipart/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-multipart/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-multipart</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-raml-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-raml-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-raml-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-types/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-types/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-types</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-maven-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/README.md
+++ b/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/README.md
@@ -19,7 +19,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "org.raml.jaxrs:jaxrs-to-raml-gradle-plugin:2.1.1-SNAPSHOT"
+    classpath "org.raml.jaxrs:jaxrs-to-raml-gradle-plugin:2.1.2-SNAPSHOT"
   }
 }
 

--- a/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-gradle-plugin-wrapper</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-maven-plugin/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jaxrs-to-raml</artifactId>
         <groupId>org.raml.jaxrs</groupId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-maven-plugin</artifactId>

--- a/jaxrs-to-raml/pom.xml
+++ b/jaxrs-to-raml/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-to-raml</artifactId>

--- a/jaxrs-to-raml/raml-api/pom.xml
+++ b/jaxrs-to-raml/raml-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-api</artifactId>

--- a/jaxrs-to-raml/raml-emitter/pom.xml
+++ b/jaxrs-to-raml/raml-emitter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-emitter</artifactId>

--- a/jaxrs-to-raml/raml-generator-api/pom.xml
+++ b/jaxrs-to-raml/raml-generator-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-generator-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.raml.jaxrs</groupId>
     <artifactId>raml-for-jaxrs</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.2-SNAPSHOT</version>
     <name>RAML to JAXRS</name>
     <description>RAML to JAXRS</description>
     <url>https://github.com/mulesoft-labs/raml-for-jax-rs</url>

--- a/raml-to-jaxrs/examples/gradle-examples/build.gradle
+++ b/raml-to-jaxrs/examples/gradle-examples/build.gradle
@@ -4,7 +4,7 @@ allprojects {
     apply plugin: 'java'
 
     group 'org.raml.jaxrs'
-    version '2.1.1-SNAPSHOT'
+    version '2.1.2-SNAPSHOT'
     repositories {
         mavenLocal()
         maven { url 'https://repository.mulesoft.org/snapshots/' }
@@ -27,7 +27,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.raml.jaxrs:raml-to-jaxrs-gradle-plugin:2.1.1-SNAPSHOT"
+        classpath "org.raml.jaxrs:raml-to-jaxrs-gradle-plugin:2.1.2-SNAPSHOT"
     }
 }
 

--- a/raml-to-jaxrs/examples/gradle-examples/gradle-jaxb-example/build.gradle
+++ b/raml-to-jaxrs/examples/gradle-examples/gradle-jaxb-example/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    compile 'org.raml.jaxrs:jaxrs-code-generator:2.1.1-SNAPSHOT'
+    compile 'org.raml.jaxrs:jaxrs-code-generator:2.1.2-SNAPSHOT'
     compile "javax.ws.rs:javax.ws.rs-api:2.0.1"
     compile "org.glassfish.jersey.media:jersey-media-moxy:2.24"
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:2.24"

--- a/raml-to-jaxrs/examples/gradle-examples/pom.xml
+++ b/raml-to-jaxrs/examples/gradle-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-gradle-examples</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/feature-plugins/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/feature-plugins/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>features</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>feature-plugins</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/feature-raml-project/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/feature-raml-project/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>features</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>feature-raml-project</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>features</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/jaxb-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/jaxb-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxb-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <!-- Repeating here for documentation -->
@@ -36,7 +36,7 @@
                 <plugin>
                     <groupId>org.raml.jaxrs</groupId>
                     <artifactId>raml-to-jaxrs-maven-plugin</artifactId>
-                    <version>2.1.1-SNAPSHOT</version>
+                    <version>2.1.2-SNAPSHOT</version>
                     <executions>
                         <execution>
                             <goals>

--- a/raml-to-jaxrs/examples/maven-examples/raml-defined-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/raml-defined-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-defined-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/references/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/references/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anonymous</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/scalar-types/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/scalar-types/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>scalar-types</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-json-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-json-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>simple-json-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-raml08/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-raml08/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>simple-raml08</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-xml-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-xml-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>simple-xml-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/type-torture-test/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/type-torture-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>type-torture-test</artifactId>

--- a/raml-to-jaxrs/examples/pom.xml
+++ b/raml-to-jaxrs/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <artifactId>examples</artifactId>
     <packaging>pom</packaging>

--- a/raml-to-jaxrs/jaxrs-code-generator/pom.xml
+++ b/raml-to-jaxrs/jaxrs-code-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-code-generator</artifactId>

--- a/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/builders/extensions/types/jackson/JacksonBasicExtension.java
+++ b/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/builders/extensions/types/jackson/JacksonBasicExtension.java
@@ -88,12 +88,12 @@ public class JacksonBasicExtension extends TypeExtensionHelper {
     typeSpec.addMethod(MethodSpec
         .methodBuilder("setAdditionalProperties")
         .returns(TypeName.VOID)
-        .addParameter(
-                      ParameterSpec.builder(ADDITIONAL_PROPERTIES_TYPE, "additionalProperties").build())
+        .addParameter(ParameterSpec.builder(ParameterizedTypeName.get(String.class), "key").build())
+        .addParameter(ParameterSpec.builder(ParameterizedTypeName.get(Object.class), "value").build())
         .addAnnotation(JsonAnySetter.class)
         .addModifiers(Modifier.PUBLIC)
         .addCode(
-                 CodeBlock.builder().add("this.additionalProperties = additionalProperties;\n").build())
+                 CodeBlock.builder().add("this.additionalProperties.put(key, value);\n").build())
         .build());
 
   }
@@ -132,8 +132,8 @@ public class JacksonBasicExtension extends TypeExtensionHelper {
     typeSpec.addMethod(MethodSpec
         .methodBuilder("setAdditionalProperties")
         .returns(TypeName.VOID)
-        .addParameter(
-                      ParameterSpec.builder(ADDITIONAL_PROPERTIES_TYPE, "additionalProperties").build())
+        .addParameter(ParameterSpec.builder(ParameterizedTypeName.get(String.class), "key").build())
+        .addParameter(ParameterSpec.builder(ParameterizedTypeName.get(Object.class), "value").build())
         .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT).build());
   }
 

--- a/raml-to-jaxrs/pom.xml
+++ b/raml-to-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>raml-to-jaxrs</artifactId>

--- a/raml-to-jaxrs/raml-to-jaxrs-cli/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <artifactId>raml-to-jaxrs-cli</artifactId>
 

--- a/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/README.md
+++ b/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/README.md
@@ -19,7 +19,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "org.raml.jaxrs:raml-to-jaxrs-gradle-plugin:2.1.1-SNAPSHOT"
+    classpath "org.raml.jaxrs:raml-to-jaxrs-gradle-plugin:2.1.2-SNAPSHOT"
   }
 }
 

--- a/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-gradle-plugin-wrapper</artifactId>

--- a/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-maven-plugin</artifactId>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>utilities</artifactId>


### PR DESCRIPTION
As part of this PR I bumped the version to `2.1.2-SNAPSHOT` and fixed the `@JsonAnySetter` method signature.

As stated on the documentation: https://fasterxml.github.io/jackson-annotations/javadoc/2.9/com/fasterxml/jackson/annotation/JsonAnySetter.html 
> two-argument method (first argument name of property, second value to set)

I'm using the library on a production project https://github.com/mulesoft/amc-agent-reg-facade so I will need to get this merged and released.