### PR TITLE
Remove dependency to a SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.raml</groupId>
                 <artifactId>raml-to-pojo</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.raml</groupId>


### PR DESCRIPTION
Use org.raml:raml-to-pojo:jar:1.0.0 instead org.raml:raml-to-pojo:jar:1.0.0-SNAPSHOT.

Please apply and release quickly as a new version.
Thank you.

