### PR TITLE
[BUG]custom annotator is not used during generation, upgrade to 0.5.1 json schema

### DIFF
--- a/raml-to-jaxrs/jaxrs-code-generator/pom.xml
+++ b/raml-to-jaxrs/jaxrs-code-generator/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
-            <version>0.4.27</version>
+            <version>0.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/JsonSchemaTypeGenerator.java
+++ b/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/JsonSchemaTypeGenerator.java
@@ -54,7 +54,16 @@ public class JsonSchemaTypeGenerator extends AbstractTypeGenerator<JCodeModel> i
   public void output(CodeContainer<JCodeModel> container, BuildPhase buildPhase) throws IOException {
 
     GenerationConfig config = build.getJsonMapperConfig();
-    final SchemaMapper mapper = new SchemaMapper(new RuleFactory(config, new Jackson2Annotator(), new SchemaStore()),
+    Jackson2Annotator annotator = new Jackson2Annotator(config);
+    Class<? extends Annotator> annotatorClass = config.getCustomAnnotator();
+    if (Jackson2Annotator.class.isAssignableFrom(annotatorClass)) {
+      try {
+        annotator = (Jackson2Annotator) annotatorClass.getConstructor(GenerationConfig.class).newInstance(config);
+      } catch (Exception err) {
+        throw new IOException(err);
+      }
+    }
+    final SchemaMapper mapper = new SchemaMapper(new RuleFactory(config, annotator, new SchemaStore()),
                                                  new SchemaGenerator());
     final JCodeModel codeModel = new JCodeModel();
 


### PR DESCRIPTION
- fix bug with custom annotator usage
- upgrade json schema plugin from 0.4.27 to 0.5.1