### PR TITLE
Issue #418: String patterns not recognized in jaxrs Path

### DIFF
--- a/raml-to-jaxrs/jaxrs-code-generator/src/test/java/org/raml/jaxrs/generator/builders/resources/ResourceBuilderTestV10.java
+++ b/raml-to-jaxrs/jaxrs-code-generator/src/test/java/org/raml/jaxrs/generator/builders/resources/ResourceBuilderTestV10.java
@@ -252,6 +252,40 @@ public class ResourceBuilderTestV10 {
   }
 
   @Test
+  public void build_with_path_param_and_pattern() throws Exception {
+
+    // https://github.com/mulesoft-labs/raml-for-jax-rs/issues/252
+    RamlV10.buildResourceV10(this, "resource_entity_no_response_pattern.raml",
+                             new CodeContainer<TypeSpec>() {
+
+                               @Override
+                               public void into(TypeSpec g) throws IOException {
+
+                                 assertEquals("Foo", g.name);
+                                 assertEquals(1, g.methodSpecs.size());
+                                 MethodSpec methodSpec = g.methodSpecs.get(0);
+                                 assertEquals("putViewingSessionAttachmentsByViewingSessionId", methodSpec.name);
+                                 assertEquals(2, methodSpec.annotations.size());
+                                 assertEquals(ClassName.get(PUT.class), methodSpec.annotations.get(0).type);
+                                 assertEquals(ClassName.get(Path.class), methodSpec.annotations.get(1).type);
+                                 assertEquals("\"/{viewingSessionId:(;[^/;]+)*}/Attachments\"",
+                                              methodSpec.annotations.get(1).members.get("value").get(0).toString());
+
+                                 assertEquals(1, methodSpec.parameters.size());
+
+                                 ParameterSpec paramOneSpec = methodSpec.parameters.get(0);
+                                 assertEquals("viewingSessionId", paramOneSpec.name);
+                                 assertEquals(ClassName.get(String.class), paramOneSpec.type);
+                                 assertEquals(1, paramOneSpec.annotations.size());
+                                 assertEquals(ClassName.get(PathParam.class), paramOneSpec.annotations.get(0).type);
+                                 assertEquals("\"viewingSessionId\"", paramOneSpec.annotations.get(0).members.get("value").get(0)
+                                     .toString());
+
+                               }
+                             }, "foo", "/fun");
+  }
+
+  @Test
   public void build_with_query_param_with_complex_types() throws Exception {
 
     // https://github.com/mulesoft-labs/raml-for-jax-rs/issues/252

--- a/raml-to-jaxrs/jaxrs-code-generator/src/test/resources/org/raml/jaxrs/generator/builders/resources/resource_entity_no_response_pattern.raml
+++ b/raml-to-jaxrs/jaxrs-code-generator/src/test/resources/org/raml/jaxrs/generator/builders/resources/resource_entity_no_response_pattern.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: GitHub API
+version: v3
+baseUri: https://api.github.com
+/ViewingSession:
+  /{viewingSessionId}:
+    /Attachments:
+      uriParameters:
+        viewingSessionId:
+          type: string
+          pattern: ^(;[^/;]+)*$
+      put:


### PR DESCRIPTION
Added path regex for jaxrs code generation.
Check if given uri parameter is a String -> Check if it has a pattern -> add regex pattern to jax-rs path

Added test:
ResourceBuilderTestV10:build_with_path_param_and_pattern

Implementation:
- Changed ResourceBuilder.java
- Added method to check for uri param pathes
- Added for methods with Path annotation
- Added for classes with Path annotation

Best regards