### PR TITLE
#421 Always use InputStream and StreamingOuput for type "any"

### DIFF
--- a/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/builders/resources/ResourceBuilder.java
+++ b/raml-to-jaxrs/jaxrs-code-generator/src/main/java/org/raml/jaxrs/generator/builders/resources/ResourceBuilder.java
@@ -209,8 +209,7 @@ public class ResourceBuilder implements ResourceGenerator {
       return;
     }
 
-    if (gRequest.type().name().equals("any") && "application/octet-stream".equals(gRequest.mediaType())) {
-
+    if (gRequest.type().name().equals("any")) {
       TypeName typeName = ClassName.get(InputStream.class);
       methodSpec.addParameter(ParameterSpec.builder(typeName, "entity").build());
     } else {
@@ -450,7 +449,7 @@ public class ResourceBuilder implements ResourceGenerator {
 
   private TypeName createResponseParameter(GResponseType responseType, MethodSpec.Builder builder) {
 
-    if ("application/octet-stream".equals(responseType.mediaType()) && "any".equals(responseType.type().name())) {
+    if ("any".equals(responseType.type().name())) {
 
       TypeName typeName = ClassName.get(StreamingOutput.class);
       builder.addParameter(ParameterSpec.builder(typeName, "entity").build());


### PR DESCRIPTION
The solution is just a one liner.

Use InputStream and StreamingOutput, where ever type "any" is used. The current solution with java.lang.Object doesn't allow a real handling of this situations.

Imagine:
```    
body:
      application/zip: 
```
Even json and other types can be handled with InputStream, but not with Object.